### PR TITLE
Add handling for trailing spaces and variables in rules names

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -967,7 +967,7 @@ rule: dependency
         // Check rule
         let rules = makefile.rules().collect::<Vec<_>>();
         assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].targets().collect::<Vec<_>>(), vec!["$", "(", "RULE", ")"]);
+        assert_eq!(rules[0].targets().collect::<Vec<_>>(), vec!["$(RULE)"]);
         assert_eq!(rules[0].prerequisites().collect::<Vec<_>>(), vec!["dependency"]);
         assert_eq!(rules[0].recipes().collect::<Vec<_>>(), vec!["command"]);
     }
@@ -986,7 +986,7 @@ rule: dependency
         let rules = makefile.rules().collect::<Vec<_>>();
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].targets().collect::<Vec<_>>(), vec!["rule"]);
-        assert_eq!(rules[0].prerequisites().collect::<Vec<_>>(), vec!["DEP"]);
+        assert_eq!(rules[0].prerequisites().collect::<Vec<_>>(), vec!["$(DEP)"]);
         assert_eq!(rules[0].recipes().collect::<Vec<_>>(), vec!["command"]);
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -861,4 +861,16 @@ rule: dependency
         let makefile = Makefile::from_reader("rule: dependency\n\tcommand\n#comment".as_bytes()).unwrap();
         assert_eq!(makefile.rules().count(), 1);
     }
+
+    #[test]
+    fn test_parse_with_variable_rule() {
+        let makefile = Makefile::from_reader("RULE := rule\n$(RULE): dependency\n\tcommand".as_bytes()).unwrap();
+        assert_eq!(makefile.rules().count(), 1);
+    }
+
+    #[test]
+    fn test_parse_with_variable_dependency() {
+        let makefile = Makefile::from_reader("DEP := dependency\nrule: (DEP)\n\tcommand".as_bytes()).unwrap();
+        assert_eq!(makefile.rules().count(), 1);
+    }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -845,8 +845,14 @@ rule: dependency
     }
 
     #[test]
-    fn test_parse_with_whitespace_after_last_newline() {
+    fn test_parse_with_tab_after_last_newline() {
         let makefile = Makefile::from_reader("rule: dependency\n\tcommand\n\t".as_bytes()).unwrap();
+        assert_eq!(makefile.rules().count(), 1);
+    }
+
+    #[test]
+    fn test_parse_with_space_after_last_newline() {
+        let makefile = Makefile::from_reader("rule: dependency\n\tcommand\n ".as_bytes()).unwrap();
         assert_eq!(makefile.rules().count(), 1);
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -234,17 +234,11 @@ fn parse(text: &str) -> Parse {
                     Some(DOLLAR) => {
                         // Look ahead to check if this is a rule pattern
                         let pos = self.tokens.len() - 1;
-                        let mut is_rule = false;
-                        
-                        // Simple scan to find a colon after the variable reference
-                        for i in (0..pos).rev() {
-                            if let Some((kind, text)) = self.tokens.get(i) {
-                                if *kind == OPERATOR && text == ":" {
-                                    is_rule = true;
-                                    break;
-                                }
-                            }
-                        }
+                        let is_rule = self.tokens[..pos]
+                            .iter()
+                            .rev()
+                            .find(|(kind, text)| *kind == OPERATOR && text == ":")
+                            .is_some();
                         
                         if is_rule {
                             self.parse_rule();


### PR DESCRIPTION
This PR aims to solve (issue 23)[https://github.com/jelmer/makefile-lossless/issues/23]. In particular, handling trailing spaces after a rule and variables in rule names.

While working on this, I realized I don't know how variables should be parsed. In the current implementation all variables just get parsed as `$(VAR)` string, but I think the correct solution would be to have a new node type that contains the name of the variable.