### PR TITLE
More complete indentation, whitespace, and variable handling 

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -90,6 +90,18 @@ impl<'a> Lexer<'a> {
                     self.line_type = Some(LineType::Recipe);
                     return Some((SyntaxKind::INDENT, "\t".to_string()));
                 }
+                (' ', None) => {
+                    // Check if this is the start of a space-indented recipe (2 or 4 spaces)
+                    let spaces = self.read_while(|ch| ch == ' ');
+                    if spaces.len() >= 2 {
+                        self.line_type = Some(LineType::Recipe);
+                        return Some((SyntaxKind::INDENT, spaces));
+                    } else {
+                        // If just a single space, treat as normal whitespace
+                        self.line_type = Some(LineType::Other);
+                        return Some((SyntaxKind::WHITESPACE, spaces));
+                    }
+                }
                 (_, None) => {
                     self.line_type = Some(LineType::Other);
                 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1620,7 +1620,7 @@ rule: dependency
     EXPR@24..34
       IDENTIFIER@24..34 "dependency"
     NEWLINE@34..35 "\n"
-    RECIPE_LINE@35..44
+    RECIPE@35..44
       INDENT@35..36 "\t"
       TEXT@36..43 "command"
       NEWLINE@43..44 "\n"
@@ -1696,7 +1696,7 @@ rule: dependency
       WHITESPACE@17..18 " "
       IDENTIFIER@18..29 "dependency2"
     NEWLINE@29..30 "\n"
-    RECIPE_LINE@30..39
+    RECIPE@30..39
       INDENT@30..31 "\t"
       TEXT@31..38 "command"
       NEWLINE@38..39 "\n"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -837,16 +837,19 @@ fn parse(text: &str) -> Parse {
                     // Look ahead to see what comes after the whitespace
                     let look_ahead_pos = self.tokens.len().saturating_sub(1);
                     let mut is_documentation_or_help = false;
-                    
+
                     if look_ahead_pos > 0 {
                         let next_token = &self.tokens[look_ahead_pos - 1];
                         // Consider this documentation if it's an identifier starting with @, a comment,
                         // or any reasonable text
-                        if next_token.0 == IDENTIFIER || next_token.0 == COMMENT || next_token.0 == TEXT {
+                        if next_token.0 == IDENTIFIER
+                            || next_token.0 == COMMENT
+                            || next_token.0 == TEXT
+                        {
                             is_documentation_or_help = true;
                         }
                     }
-                    
+
                     if is_documentation_or_help {
                         // For documentation/help text lines, just consume all tokens until newline
                         // without generating errors
@@ -865,11 +868,11 @@ fn parse(text: &str) -> Parse {
                 Some(INDENT) => {
                     // Previously we would error here, but now we'll treat it as a possible recipe
                     // Let's check if we're currently in a rule
-                    
+
                     // We'll consume it anyway, but won't generate an error for now
                     // If it's truly invalid, other parsing steps will catch the issue
                     self.bump();
-                    
+
                     // Consume rest of the line without errors, since it might be documentation
                     while self.current().is_some() && self.current() != Some(NEWLINE) {
                         self.bump();
@@ -1497,10 +1500,10 @@ impl Rule {
             .children()
             .filter(|it| it.kind() == RECIPE)
             .nth(i);
-            
+
         let index = match index {
             Some(node) => node.index(),
-            None => return None
+            None => return None,
         };
 
         let mut builder = GreenNodeBuilder::new();
@@ -1511,10 +1514,10 @@ impl Rule {
         builder.finish_node();
 
         let syntax = SyntaxNode::new_root_mut(builder.finish());
-        
+
         let clone = self.0.clone();
         clone.splice_children(index..index + 1, vec![syntax.into()]);
-        
+
         Some(Rule(clone))
     }
 
@@ -1550,7 +1553,7 @@ impl Rule {
 
         let clone = self.0.clone();
         clone.splice_children(index..index, vec![syntax.into()]);
-        
+
         Rule(clone)
     }
 }
@@ -1765,7 +1768,7 @@ rule: dependency
     fn test_push_command() {
         let mut makefile = Makefile::new();
         let rule = makefile.add_rule("rule");
-        
+
         // Create a new rule with the first command added
         let rule_with_cmd1 = rule.push_command("command");
         // Create a new rule with the second command added
@@ -1785,14 +1788,17 @@ rule: dependency
         );
 
         // Check if the original rule was modified
-        assert_eq!(rule.recipes().collect::<Vec<_>>(), vec!["command", "command2", "command3"]);
-        
+        assert_eq!(
+            rule.recipes().collect::<Vec<_>>(),
+            vec!["command", "command2", "command3"]
+        );
+
         // Check if the original makefile was modified
         assert_eq!(
             makefile.to_string(),
             "rule:\n\tcommand\n\tcommand2\n\tcommand3\n"
         );
-        
+
         // The modified rule should have the same string representation
         assert_eq!(
             rule_with_all.to_string(),
@@ -1824,14 +1830,14 @@ rule: dependency
         );
 
         // Check if the original rule was modified
-        assert_eq!(rule.recipes().collect::<Vec<_>>(), vec!["new command", "command2"]);
-        
-        // Check if the original makefile was modified
         assert_eq!(
-            makefile.to_string(),
-            "rule:\n\tnew command\n\tcommand2\n"
+            rule.recipes().collect::<Vec<_>>(),
+            vec!["new command", "command2"]
         );
-        
+
+        // Check if the original makefile was modified
+        assert_eq!(makefile.to_string(), "rule:\n\tnew command\n\tcommand2\n");
+
         // The modified rule should have the same string representation
         assert_eq!(
             modified_rule.to_string(),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2630,8 +2630,6 @@ all: $(OBJS)
         assert!(parsed.errors.is_empty());
     }
 
-    // ISSUE 1: Multiline Variable Handling Tests
-
     #[test]
     fn test_multiline_variable_with_backslash() {
         let content = r#"
@@ -2705,8 +2703,6 @@ CFLAGS := -Wall -O2 \
         );
     }
 
-    // ISSUE 2: Indented Line Tests
-
     #[test]
     fn test_indented_help_text() {
         let content = r#"
@@ -2765,8 +2761,6 @@ endif
         assert!(code.contains("endif"));
     }
 
-    // ISSUE 3: Colon vs Assignment Operators
-
     #[test]
     fn test_recipe_with_colon() {
         let content = r#"
@@ -2815,8 +2809,6 @@ all:: prerequisite2
             "Expected to find at least one rule containing 'all'"
         );
     }
-
-    // ISSUE 4: Conditionals and elif Tests
 
     #[test]
     fn test_elif_directive() {
@@ -2898,8 +2890,6 @@ endif
         assert!(code.contains("ifneq"));
     }
 
-    // ISSUE 5: Tab vs Space for Recipes
-
     #[test]
     fn test_space_indented_recipes() {
         // This test is expected to fail with current implementation
@@ -2922,8 +2912,6 @@ build:
         let build_rule = rules.iter().find(|r| r.targets().any(|t| t == "build"));
         assert!(build_rule.is_some(), "Expected to find build rule");
     }
-
-    // ISSUE 7: Advanced Variable Expansions
 
     #[test]
     fn test_complex_variable_functions() {
@@ -2956,8 +2944,6 @@ INSTALL_PATH = $(shell echo $(PREFIX) | sed 's/\/$//')
             parsed.errors
         );
     }
-
-    // ISSUE 8: Special Directives
 
     #[test]
     fn test_special_directives() {


### PR DESCRIPTION
I have run this against 10 real world makefiles, and they all parse either in strict or relaxed mode after these changes. 