### PR TITLE
Fix quoted strings breaking $(...) parsing

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -41,6 +41,30 @@ impl<'a> Lexer<'a> {
             || c == '%'
     }
 
+    /// Check whether a matching close-quote appears on the current line.
+    /// Make doesn't treat quotes as syntactic; we only group them so that
+    /// embedded parens don't confuse $(...) parsing. If the quote is
+    /// unterminated (or asymmetric, like `it's`), grouping would do more
+    /// harm than good — so we only group when there's a partner on the
+    /// same line. A backslash escapes the next character.
+    fn has_matching_close_quote(&self, quote: char) -> bool {
+        let mut probe = self.input.clone();
+        probe.next(); // Skip the opening quote we already peeked.
+        while let Some(c) = probe.next() {
+            if Self::is_newline(c) {
+                return false;
+            }
+            if c == '\\' {
+                probe.next();
+                continue;
+            }
+            if c == quote {
+                return true;
+            }
+        }
+        false
+    }
+
     fn read_quoted_string(&mut self) -> String {
         let mut result = String::new();
         let quote = self.input.next().unwrap(); // Consume opening quote
@@ -57,10 +81,6 @@ impl<'a> Lexer<'a> {
                 if let Some(next) = self.input.next() {
                     result.push(next);
                 }
-            } else if c == '$' {
-                // Handle variable references inside quotes
-                result.push(c);
-                self.input.next();
             } else {
                 result.push(c);
                 self.input.next();
@@ -152,7 +172,16 @@ impl<'a> Lexer<'a> {
                         SyntaxKind::IDENTIFIER,
                         self.read_while(Self::is_valid_identifier_char),
                     )),
-                    '"' | '\'' => Some((SyntaxKind::QUOTE, self.read_quoted_string())),
+                    '"' | '\'' => {
+                        if self.has_matching_close_quote(c) {
+                            Some((SyntaxKind::QUOTE, self.read_quoted_string()))
+                        } else {
+                            // Lone quote — emit as a single-character QUOTE
+                            // token so paren counting in $(...) still works.
+                            self.input.next();
+                            Some((SyntaxKind::QUOTE, c.to_string()))
+                        }
+                    }
                     ':' | '=' | '?' | '+' => {
                         let text = self.input.next().unwrap().to_string()
                             + self

--- a/src/lossless.rs
+++ b/src/lossless.rs
@@ -817,12 +817,10 @@ pub(crate) fn parse(text: &str, variant: Option<MakefileVariant>) -> Parse {
             self.expect_eol();
         }
 
-        // Handle parsing a quoted string - combines common quoting logic
+        // Handle parsing a quoted string. The lexer emits the entire quoted
+        // string (including both delimiters) as a single QUOTE token, so we
+        // just consume that one token.
         fn parse_quoted_string(&mut self) {
-            self.bump(); // Consume the quote
-            while !self.is_at_eof() && self.current() != Some(QUOTE) {
-                self.bump();
-            }
             if self.current() == Some(QUOTE) {
                 self.bump();
             }
@@ -7618,5 +7616,30 @@ mod test_continuation {
         assert!(kinds.contains(&DOLLAR));
         assert!(kinds.contains(&LBRACE));
         assert!(kinds.contains(&RBRACE));
+    }
+
+    #[test]
+    fn test_parse_quoted_string_inside_function_call() {
+        // The lexer emits a balanced quoted string as one QUOTE token, so a
+        // quoted argument with embedded parentheses must not break paren
+        // balance tracking inside a $(...) expression. Lone or asymmetric
+        // quotes (it's, foo'bar) must not swallow the rest of the line.
+        let cases = [
+            "X = $(if a,'foo')\n",
+            "X = $(if a,'foo (bar)')\n",
+            "X = $(if a,'(')\n",
+            "X = $(if a,')')\n",
+            "X = $(if $(SKIP),-k 'not ($(call f,$(s),$(SKIP)))')\n",
+            "X = foo'bar\nY = baz\n",
+            "X = it's fine\n",
+            "X = $(if a,it's)\n",
+            "X = '\nY = bar\n",
+        ];
+        for src in cases {
+            let parsed: Makefile = src.parse().unwrap_or_else(|e| {
+                panic!("failed to parse {src:?}: {e:?}");
+            });
+            assert_eq!(parsed.to_string(), src, "round-trip mismatch for {src:?}");
+        }
     }
 }


### PR DESCRIPTION
Two bugs caused makefiles like numpy's debian/rules to fail parsing when a $(...) function call contained a quoted argument.