### PR TITLE
Add tests for AST accessors and mutation coverage

### DIFF
--- a/src/ast/makefile.rs
+++ b/src/ast/makefile.rs
@@ -1797,6 +1797,71 @@ mod tests {
     }
 
     #[test]
+    fn test_makefile_item_remove_comments_with_one_blank_line() {
+        // A single blank line between the comments and the item is consumed
+        // along with the comments (one blank-line newline removed).
+        let makefile: Makefile = "# c1\n# c2\n\nVAR = value\n".parse().unwrap();
+        let mut item = makefile.items().last().unwrap();
+        let count = item.remove_comments().unwrap();
+
+        assert_eq!(count, 2);
+        assert_eq!(makefile.to_string(), "\nVAR = value\n");
+    }
+
+    #[test]
+    fn test_makefile_item_remove_comments_keeps_extra_blank_lines() {
+        // Only one blank-line newline is removed; a second blank line stays.
+        let makefile: Makefile = "# c1\n# c2\n\n\nVAR = value\n".parse().unwrap();
+        let mut item = makefile.items().last().unwrap();
+        let count = item.remove_comments().unwrap();
+
+        assert_eq!(count, 2);
+        assert_eq!(makefile.to_string(), "\n\nVAR = value\n");
+    }
+
+    #[test]
+    fn test_makefile_item_remove_comments_stops_at_preceding_item() {
+        // Comments are collected only back to the previous item, and the blank
+        // line before the comment is preserved (it belongs to the item above).
+        let makefile: Makefile = "VAR0 = x\n\n# c1\nVAR = value\n".parse().unwrap();
+        let mut item = makefile.items().last().unwrap();
+        let count = item.remove_comments().unwrap();
+
+        assert_eq!(count, 1);
+        assert_eq!(makefile.to_string(), "VAR0 = x\nVAR = value\n");
+    }
+
+    #[test]
+    fn test_makefile_item_add_comment_exact_output() {
+        let makefile: Makefile = "VAR = value\n".parse().unwrap();
+        let mut item = makefile.items().next().unwrap();
+        item.add_comment("note").unwrap();
+        assert_eq!(makefile.to_string(), "# note\nVAR = value\n");
+    }
+
+    #[test]
+    fn test_makefile_item_remove_comments_strips_trailing_whitespace() {
+        // Trailing whitespace on the removed comment line is removed too.
+        let makefile: Makefile = "# c1  \nVAR = value\n".parse().unwrap();
+        let mut item = makefile.items().last().unwrap();
+        let count = item.remove_comments().unwrap();
+
+        assert_eq!(count, 1);
+        assert_eq!(makefile.to_string(), "VAR = value\n");
+    }
+
+    #[test]
+    fn test_makefile_item_remove_comments_stops_at_shebang() {
+        // A shebang line is not a removable comment; nothing is removed.
+        let makefile: Makefile = "#!/usr/bin/make -f\nVAR = value\n".parse().unwrap();
+        let mut item = makefile.items().last().unwrap();
+        let count = item.remove_comments().unwrap();
+
+        assert_eq!(count, 0);
+        assert_eq!(makefile.to_string(), "#!/usr/bin/make -f\nVAR = value\n");
+    }
+
+    #[test]
     fn test_makefile_item_modify_comment() {
         let makefile: Makefile = "# Old comment\nVAR = value\n".parse().unwrap();
         let mut item = makefile.items().next().unwrap();
@@ -2257,5 +2322,44 @@ override_dh_auto_configure:
         let blocks: Vec<_> = makefile.comment_blocks().collect();
         // Blank lines between comments should still form a block
         assert_eq!(blocks.len(), 1);
+    }
+
+    #[test]
+    fn test_insert_rule_at_front() {
+        let mut makefile: Makefile = "a:\n\tx\n\nb:\n\ty\n".parse().unwrap();
+        let new_rule: Rule = "new:\n\tz\n".parse().unwrap();
+        makefile.insert_rule(0, new_rule).unwrap();
+        assert_eq!(makefile.to_string(), "new:\n\tz\n\na:\n\tx\n\nb:\n\ty\n");
+    }
+
+    #[test]
+    fn test_insert_rule_in_middle_no_blank_before_target() {
+        let mut makefile: Makefile = "a:\n\tx\nb:\n\ty\n".parse().unwrap();
+        let new_rule: Rule = "new:\n\tz\n".parse().unwrap();
+        makefile.insert_rule(1, new_rule).unwrap();
+        assert_eq!(makefile.to_string(), "a:\n\tx\n\nnew:\n\tz\n\nb:\n\ty\n");
+    }
+
+    #[test]
+    fn test_insert_rule_in_middle_blank_before_target() {
+        let mut makefile: Makefile = "a:\n\tx\n\nb:\n\ty\n".parse().unwrap();
+        let new_rule: Rule = "new:\n\tz\n".parse().unwrap();
+        makefile.insert_rule(1, new_rule).unwrap();
+        assert_eq!(makefile.to_string(), "a:\n\tx\n\n\nnew:\n\tz\n\nb:\n\ty\n");
+    }
+
+    #[test]
+    fn test_insert_rule_at_end() {
+        let mut makefile: Makefile = "a:\n\tx\n".parse().unwrap();
+        let new_rule: Rule = "new:\n\tz\n".parse().unwrap();
+        makefile.insert_rule(1, new_rule).unwrap();
+        assert_eq!(makefile.to_string(), "a:\n\tx\n\nnew:\n\tz\n");
+    }
+
+    #[test]
+    fn test_insert_rule_out_of_bounds() {
+        let mut makefile: Makefile = "a:\n\tx\n".parse().unwrap();
+        let new_rule: Rule = "new:\n\tz\n".parse().unwrap();
+        assert!(makefile.insert_rule(5, new_rule).is_err());
     }
 }

--- a/src/ast/rule.rs
+++ b/src/ast/rule.rs
@@ -1192,7 +1192,7 @@ impl Default for Makefile {
 
 #[cfg(test)]
 mod tests {
-    use crate::Makefile;
+    use crate::{Makefile, Rule};
 
     #[test]
     fn test_rules_with_pipe_in_shell_continuation() {
@@ -1220,5 +1220,57 @@ mod tests {
 
         let output = makefile.to_string();
         assert_eq!(input, output, "Round-trip failed");
+    }
+
+    #[test]
+    fn test_targets_multiple() {
+        let rule: Rule = "a b c: dep\n\tcmd".parse().unwrap();
+        assert_eq!(rule.targets().collect::<Vec<_>>(), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_targets_archive_member_keeps_parens() {
+        let rule: Rule = "lib.a(obj.o): dep\n\tcmd".parse().unwrap();
+        assert_eq!(rule.targets().collect::<Vec<_>>(), vec!["lib.a(obj.o)"]);
+    }
+
+    #[test]
+    fn test_targets_archive_member_keeps_inner_whitespace() {
+        // Whitespace inside the parentheses must not split the target: the
+        // in_parens depth counter keeps the whole member together.
+        let rule: Rule = "lib.a(a.o b.o): dep\n\tcmd".parse().unwrap();
+        assert_eq!(rule.targets().collect::<Vec<_>>(), vec!["lib.a(a.o b.o)"]);
+    }
+
+    #[test]
+    fn test_targets_variable_reference() {
+        let rule: Rule = "$(VAR): dep\n\tcmd".parse().unwrap();
+        assert_eq!(rule.targets().collect::<Vec<_>>(), vec!["$(VAR)"]);
+    }
+
+    #[test]
+    fn test_is_double_colon_true() {
+        let rule: Rule = "all:: dep\n\tcmd".parse().unwrap();
+        assert!(rule.is_double_colon());
+    }
+
+    #[test]
+    fn test_is_double_colon_false() {
+        let rule: Rule = "all: dep\n\tcmd".parse().unwrap();
+        assert!(!rule.is_double_colon());
+    }
+
+    #[test]
+    fn test_set_targets_multiple_separated_by_single_space() {
+        let mut rule: Rule = "old: dep\n\tcmd\n".parse().unwrap();
+        rule.set_targets(vec!["a", "b", "c"]).unwrap();
+        assert_eq!(rule.to_string(), "a b c: dep\n\tcmd\n");
+    }
+
+    #[test]
+    fn test_rule_item_recipe_debug() {
+        let rule: Rule = "all:\n\techo hi\n".parse().unwrap();
+        let items: Vec<_> = rule.items().collect();
+        assert_eq!(format!("{:?}", items[0]), "Recipe(\"echo hi\")");
     }
 }

--- a/src/ast/variable.rs
+++ b/src/ast/variable.rs
@@ -393,6 +393,29 @@ mod tests {
     }
 
     #[test]
+    fn test_is_define_true() {
+        let makefile: Makefile = "define greeting\necho hello\nendef\n".parse().unwrap();
+        let var = makefile.variable_definitions().next().unwrap();
+        assert!(var.is_define());
+    }
+
+    #[test]
+    fn test_is_define_false_for_plain_assignment() {
+        let makefile: Makefile = "VAR = value\n".parse().unwrap();
+        let var = makefile.variable_definitions().next().unwrap();
+        assert!(!var.is_define());
+    }
+
+    #[test]
+    fn test_is_define_false_for_value_containing_define_word() {
+        // The identifier check must look for a `define` keyword token, not a
+        // value that merely contains the word.
+        let makefile: Makefile = "VAR = define\n".parse().unwrap();
+        let var = makefile.variable_definitions().next().unwrap();
+        assert!(!var.is_define());
+    }
+
+    #[test]
     fn test_set_assignment_operator_simple_to_conditional() {
         let makefile: Makefile = "VAR = value\n".parse().unwrap();
         let mut var = makefile.variable_definitions().next().unwrap();

--- a/src/ast/vpath.rs
+++ b/src/ast/vpath.rs
@@ -60,3 +60,60 @@ impl Vpath {
             .map(|n| n.text().to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lossless::parse;
+
+    fn vpath_of(input: &str) -> Vpath {
+        let parsed = parse(input, None);
+        assert!(
+            parsed.errors.is_empty(),
+            "unexpected errors: {:?}",
+            parsed.errors
+        );
+        parsed
+            .root()
+            .syntax()
+            .descendants()
+            .find_map(Vpath::cast)
+            .expect("no VPATH node")
+    }
+
+    #[test]
+    fn test_pattern_keyword_only() {
+        assert_eq!(vpath_of("vpath\n").pattern(), None);
+    }
+
+    #[test]
+    fn test_pattern_with_pattern_only() {
+        assert_eq!(vpath_of("vpath %.c\n").pattern(), Some("%.c".to_string()));
+    }
+
+    #[test]
+    fn test_pattern_with_pattern_and_dirs() {
+        assert_eq!(
+            vpath_of("vpath %.c src:lib\n").pattern(),
+            Some("%.c".to_string())
+        );
+    }
+
+    #[test]
+    fn test_directories_text_none_when_keyword_only() {
+        assert_eq!(vpath_of("vpath\n").directories_text(), None);
+    }
+
+    #[test]
+    fn test_directories_text_none_when_pattern_only() {
+        assert_eq!(vpath_of("vpath %.c\n").directories_text(), None);
+    }
+
+    #[test]
+    fn test_directories_text_present() {
+        assert_eq!(
+            vpath_of("vpath %.c src:lib\n").directories_text(),
+            Some("src:lib".to_string())
+        );
+    }
+}


### PR DESCRIPTION
Cover Vpath::pattern/directories_text, VariableDefinition::is_define, Rule target extraction and double-colon detection, and Makefile comment removal and rule insertion, killing mutants surfaced by cargo mutants.